### PR TITLE
Remote Copy Workflow

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -141,4 +141,7 @@ jobs:
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
         run: |
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           setfacl --recursive --modify "${{ inputs.target-acl-spec }}" ${{ inputs.target }}
+          getfacl -t ${{ inputs.target }}
+          EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -55,17 +55,71 @@ jobs:
             exit 1
           fi
 
+  test-acl:
+    name: Test ACL
+    runs-on: ubuntu-latest
+    if: inputs.target-acl-spec != ''
+    container: rockylinux/rockylinux:8.10
+    env:
+      TEST_DIR: /opt/test
+    steps:
+      - name: Format ACL
+        id: fmt
+        # Remove spaces from ACL string as we have later logic that relies on
+        # the IFS=,
+        run: |
+          acl=$(echo '${{ inputs.target-acl-spec }}' | tr -d ' ')
+          echo "Formatted ACL: $acl
+          echo "acl=$acl" >> $GITHUB_OUTPUT
+
+      - name: Create Users in ACL String
+        # We don't error out here as it could have been because we are adding the same user twice
+        run: |
+          set +e
+          acl="${{ steps.fmt.outputs.acl }}"
+          IFS=,
+          for entry in $acl; do
+            echo "Testing ACL for u(ser): $entry"
+            if [[ $entry =~ ^u(ser)?:([^:]+): ]]; then
+              user="${BASH_REMATCH[2]}"
+              echo "Adding user $user"
+              useradd $user
+            fi
+          done
+
+      - name: Create Groups in ACL String
+        # We don't error out here as it could have been because we are adding the same group twice
+        run: |
+          set +e
+          acl="${{ steps.fmt.outputs.acl }}"
+          IFS=,
+          for entry in $acl; do
+            if [[ $entry =~ ^g(roup)?:([^:]+): ]]; then
+              echo "Testing ACL for g(roup): $entry"
+              group="${BASH_REMATCH[2]}"
+              echo "Adding group $group"
+              groupadd $group
+            fi
+          done
+
       - name: Verify Valid ACL Spec
-        if: inputs.target-acl-spec != ''
-        env:
-          TEST_DIR: ./test
+        # Now that we have created the users and groups from the ACL string, check if it is valid!
         run: |
           mkdir ${{ env.TEST_DIR }}
-          setfacl --test --recursive --modify "${{ inputs.target-acl-spec }}" ${{ env.TEST_DIR }}
+          echo "---- Users ----"
+          cut -d: -f1 /etc/passwd
+
+          echo "---- Groups ----"
+          groups
+
+          setfacl --test --recursive --modify "${{ steps.fmt.outputs.acl }}" ${{ env.TEST_DIR }}
 
   remote:
     name: Remote
     runs-on: ubuntu-latest
+    needs:
+      - setup
+      - test-acl
     environment: ${{ inputs.remote-environment }}
     steps:
       - name: Setup SSH

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -42,41 +42,46 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    outputs:
+      # The `inputs.target-acl-spec` with spaces removed
+      formatted-acl: ${{ steps.fmt.outputs.acl }}
     steps:
       - name: Log inputs
         run: |
-          echo ""::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
+          echo "::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
           echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
 
       - name: Verify Remote Target
         run: |
-          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "true" ]]; then
+          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "false" ]]; then
             echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
             exit 1
           fi
 
-  test-acl:
-    name: Test ACL
-    runs-on: ubuntu-latest
-    if: inputs.target-acl-spec != ''
-    container: rockylinux/rockylinux:8.10
-    env:
-      TEST_DIR: /opt/test
-    steps:
       - name: Format ACL
         id: fmt
         # Remove spaces from ACL string as we have later logic that relies on
         # the IFS=,
         run: |
           acl=$(echo '${{ inputs.target-acl-spec }}' | tr -d ' ')
-          echo "Formatted ACL: $acl
+          echo "Formatted ACL: $acl"
           echo "acl=$acl" >> $GITHUB_OUTPUT
 
+  test-acl:
+    name: Test ACL
+    runs-on: ubuntu-latest
+    if: inputs.target-acl-spec != ''
+    needs:
+      - setup
+    container: rockylinux/rockylinux:8.10
+    env:
+      TEST_DIR: /opt/test
+    steps:
       - name: Create Users in ACL String
         # We don't error out here as it could have been because we are adding the same user twice
         run: |
           set +e
-          acl="${{ steps.fmt.outputs.acl }}"
+          acl="${{ needs.setup.outputs.formatted-acl }}"
           IFS=,
           for entry in $acl; do
             echo "Testing ACL for u(ser): $entry"
@@ -91,7 +96,7 @@ jobs:
         # We don't error out here as it could have been because we are adding the same group twice
         run: |
           set +e
-          acl="${{ steps.fmt.outputs.acl }}"
+          acl="${{ needs.setup.outputs.formatted-acl }}"
           IFS=,
           for entry in $acl; do
             if [[ $entry =~ ^g(roup)?:([^:]+): ]]; then
@@ -112,7 +117,7 @@ jobs:
           echo "---- Groups ----"
           groups
 
-          setfacl --test --recursive --modify "${{ steps.fmt.outputs.acl }}" ${{ env.TEST_DIR }}
+          setfacl --test --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ env.TEST_DIR }}
 
   remote:
     name: Remote
@@ -133,15 +138,16 @@ jobs:
 
       - name: Rsync Source to Target
         run: |
-          rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          rsync --recursive --verbose \
             ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
-            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.source }}' \
-            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.target }}'
+            ${{ inputs.source }} ${{ inputs.target }}
+          EOT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          setfacl --recursive --modify "${{ inputs.target-acl-spec }}" ${{ inputs.target }}
+          setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ inputs.target }}
           getfacl -t ${{ inputs.target }}
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -198,9 +198,7 @@ jobs:
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} \
             ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
-          paths=$(cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})
-          echo "paths are $paths"
-          echo "paths=$paths" >> $GITHUB_OUTPUT
+          echo "paths=$(cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
@@ -243,9 +241,7 @@ jobs:
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} \
             ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
-          paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})
-          echo "paths are $paths"
-          echo "paths=$paths" >> $GITHUB_OUTPUT
+          echo "paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
   copy-to-tape-gadi:
     name: Copy To Tape On ${{ inputs.remote-environment }}

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -13,11 +13,11 @@ on:
       source:
         type: string
         required: true
-        description: Remote absolute path to configuration input file/folder
+        description: Remote absolute path to configuration input source
       target:
         type: string
         required: true
-        description: Remote absolute path for the copied configuration input file/folder
+        description: Remote absolute path to configuration input destination
       overwrite-target:
         type: boolean
         required: true

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -9,6 +9,7 @@ on:
         description: The Github Environment for the given remote
         options:
           - Gadi
+          - Gadi Prerelease
       source:
         type: string
         required: true
@@ -137,6 +138,11 @@ jobs:
       - setup
       - test-acl
     environment: ${{ inputs.remote-environment }}
+    outputs:
+      # Space-separated list of paths copied to the target
+      files: ${{ steps.copy.outputs.paths }}
+      # Space-separated list of manifests created at the target
+      manifests: ${{ steps.manifest.outputs.paths }}
     steps:
       - name: Setup SSH
         id: ssh
@@ -148,12 +154,23 @@ jobs:
             ${{ secrets.SSH_HOST_DATA }}
 
       - name: Rsync Source to Target
+        id: copy
+        env:
+          REMOTE_RSYNC_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-files-${{ github.run_id }}.log
+        # In this step, we rsync the files from the source to the target,
+        # capturing the list of files copied as output of the step, since
+        # it's used in the manifest step.
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          rsync --recursive --verbose \
-            ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
-            ${{ inputs.source }} ${{ inputs.target }}
+          files=$(rsync --recursive --out-format="%n" \
+              ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
+              ${{ inputs.source }} ${{ inputs.target }} \
+            | tr '\n' ' ' \  # convert to space-separated for output
+            > ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
+          )
           EOT
+
+          echo "paths=$(scp -q ${{ secrets.USER }}:${{ secrets.HOST }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
@@ -162,6 +179,29 @@ jobs:
           setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ inputs.target }}
           getfacl -t ${{ inputs.target }}
           EOT
+
+      - name: Update Manifests
+        id: manifest
+        env:
+          REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}.log
+        # Generate manifests for files copied over in the earlier rsync job
+        run: |
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          # FIXME: Make these module use/load an environment variable
+          module use /g/data/vk83/prerelease/modules
+          module load payu
+
+          manifest_paths=()
+          while read -r path:
+            cd $(dirname $path)
+            manifest_dir=$(basename $path)
+            yamf add -n manifest.yaml --force $manifest_dir
+            manifest_paths+=("$manifest_dir/manifest.yaml")
+          done <<< "${{ steps.copy.outputs.paths }}"
+          echo "${manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
+          EOT
+
+          echo "paths=$(scp -q ${{ secrets.USER }}:${{ secrets.HOST }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
 
   copy-to-tape:
     name: Copy To Tape
@@ -172,7 +212,8 @@ jobs:
     if: inputs.store-on-tape && inputs.remote-environment == 'Gadi'
     environment: ${{ inputs.remote-environment }}
     env:
-      TAPE_ROOT_DIR: 'FIXME: Where is it?'
+      TAPE_ROOT_DIR: model-config-inputs
+      PROJECT_CODE: vk83
     steps:
       - name: Setup SSH
         id: ssh
@@ -187,6 +228,7 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           now=$(date +%Y_%m_%d_%H_%M)
-          mdss mkdir ${{ env.TAPE_ROOT_DIR }}/$now
-          mdss put -r -w ${{ inputs.target }} ${{ env.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ env.PROJECT_CODE }} mkdir -p ${{ env.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ env.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.files }} ${{ env.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ env.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.manifests }} ${{ env.TAPE_ROOT_DIR }}/$now
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -273,17 +273,8 @@ jobs:
           now=$(date +%Y_%m_%d_%H_%M)
 
           mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now
-          for file in ${{ needs.copy-to-remote.outputs.files }}; do
-            file_relative_to_target=${file#${{ inputs.target }}/}
-            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target'"
-            dirs_after_target=$(dirname $file_relative_to_target)
-            if [[ "$dirs_after_target" != "." ]]; then
-              mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)
-            fi
-            mdss -P ${{ vars.PROJECT_CODE }} put -r $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target
-          done
 
-          for file in ${{ needs.copy-to-remote.outputs.manifests }}; do
+          for file in ${{ needs.copy-to-remote.outputs.files }} ${{ needs.copy-to-remote.outputs.manifests }}; do
             file_relative_to_target=${file#${{ inputs.target }}/}
             echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target'"
             dirs_after_target=$(dirname $file_relative_to_target)

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -1,0 +1,90 @@
+name: Config Inputs Remote Copy
+run-name: "${{ inputs.remote-environment }} Config Input Copy to ${{ inputs.target }}"
+on:
+  workflow_dispatch:
+    inputs:
+      remote-environment:
+        type: choice
+        required: true
+        description: The Github Environment for the given remote
+        options:
+          - Gadi
+      source:
+        type: string
+        required: true
+        description: Remote absolute path to configuration input file/folder
+      target:
+        type: string
+        required: true
+        description: Remote absolute path for the copied configuration input file/folder
+      overwrite-target:
+        type: boolean
+        required: true
+        description: Overwrite the remote target if it already exists
+      target-acl-spec:
+        type: string
+        required: true
+        # Default to no write for everyone except tm70_ci
+        # TODO: This default will probably not work for other `remote-environment`s
+        default: >-
+          u::rwx,
+          u:tm70_ci:rwx,
+          g::r-x,
+          m::rwx,
+          o::---,
+          d:u::rwx,
+          d:u:tm70_ci:rwx,
+          d:g::r-x,
+          d:m::rwx,
+          d:o::---
+        description: ACL spec to be passed to `setfacl -m` for the given target
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log inputs
+        run: |
+          echo ""::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
+          echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
+
+      - name: Verify Remote Target
+        run: |
+          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "true" ]]; then
+            echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
+            exit 1
+          fi
+
+      - name: Verify Valid ACL Spec
+        if: inputs.target-acl-spec != ''
+        env:
+          TEST_DIR: ./test
+        run: |
+          mkdir ${{ env.TEST_DIR }}
+          setfacl --test --recursive --modify "${{ inputs.target-acl-spec }}" ${{ env.TEST_DIR }}
+
+  remote:
+    name: Remote
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.remote-environment }}
+    steps:
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          private-key: ${{ secrets.SSH_KEY }}
+          hosts: |
+            ${{ secrets.SSH_HOST }}
+            ${{ secrets.SSH_HOST_DATA }}
+
+      - name: Rsync Source to Target
+        run: |
+          rsync --recursive --verbose -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
+            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.source }}' \
+            '${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ inputs.target }}'
+
+      - name: Set ACLs on Target
+        if: inputs.target-acl-spec != ''
+        run: |
+          setfacl --recursive --modify "${{ inputs.target-acl-spec }}" ${{ inputs.target }}

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -229,10 +229,10 @@ jobs:
             echo "Path is $path"
             manifest_dir=$(dirname $path)
             cd $manifest_dir || exit
-            manifest_file=$(basename $path)
-            echo "Generating a manifest entry in $manifest_dir for $manifest_file"
+            manifest_entry_filename=$(basename $path)
+            echo "Generating a manifest entry in $manifest_dir for $manifest_entry_filename"
 
-            yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_file
+            yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_entry_filename
             manifest_paths["$manifest_dir/${{ env.MANIFEST_FILE_NAME }}"]=1
           done
           echo "${!manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -230,7 +230,7 @@ jobs:
             manifest_dir=$(dirname $path)
             cd $manifest_dir || exit
             manifest_file=$(basename $path)
-            echo "Generating a manifest in $manifest_dir for $manifest_file"
+            echo "Generating a manifest entry in $manifest_dir for $manifest_file"
 
             yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_file
             manifest_paths+=("$manifest_dir/${{ env.MANIFEST_FILE_NAME }}")

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -176,12 +176,15 @@ jobs:
 
       - name: Rsync Source to Target
         id: copy
+        # output:
+        #   paths: space-separated list of files copied
         env:
           REMOTE_RSYNC_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-files-${{ github.run_id }}.log
           LOCAL_RSYNC_FILE_LIST_PATH: ./files-copied.log
-        # In this step, we rsync the files from the source to the target,
-        # capturing the list of files copied as output of the step, since
-        # it's used in the manifest step.
+        # In this step, we rsync the files from the source to the target, capturing the list of files copied.
+        # We also remove the empty directories copied, and make it space-separated.
+        # There are two rsync steps, one for the rsyncing of source to target,
+        # and then one locally on the runner to copy the list of files from the remote.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           rsync --recursive --out-format="${{ inputs.target }}/%n" \
@@ -189,13 +192,12 @@ jobs:
               ${{ inputs.source }} ${{ inputs.target }} \
             | grep --invert-match '/$' \
             | tr '\n' ' ' \
-            > ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
+            | tee ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
           EOT
 
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} \
             ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
-          cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
           paths=$(cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})
           echo "paths are $paths"
           echo "paths=$paths" >> $GITHUB_OUTPUT
@@ -210,11 +212,15 @@ jobs:
 
       - name: Update Manifests
         id: manifest
+        # output:
+        #   paths: space-separated list of manifests created
         env:
           REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}.log
           LOCAL_MANIFEST_FILE_LIST_PATH: ./manifests-copied.log
           MANIFEST_FILE_NAME: manifest.yaml
-        # Generate manifests for files copied over in the earlier rsync job
+        # Generate manifests for files copied over in the earlier rsync job.
+        # Similar to the copy step, we generate a list of manifest paths created on the remote,
+        # then copy that to the runner locally so we can set it as output.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           module use ${{ vars.YAMF_MODULE_PATH }}
@@ -227,6 +233,7 @@ jobs:
             cd $manifest_dir || exit
             manifest_file=$(basename $path)
             echo "Generating a manifest in $manifest_dir for $manifest_file"
+
             yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_file
             manifest_paths+=("$manifest_dir/${{ env.MANIFEST_FILE_NAME }}")
           done
@@ -236,17 +243,15 @@ jobs:
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} \
             ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
-          cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
           paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})
           echo "paths are $paths"
           echo "paths=$paths" >> $GITHUB_OUTPUT
 
-  copy-to-tape:
-    name: Copy To Tape
+  copy-to-tape-gadi:
+    name: Copy To Tape On ${{ inputs.remote-environment }}
     runs-on: ubuntu-latest
     needs:
       - copy-to-remote
-    # TODO: Generalize the copy-to-tape job for future remote-environments
     if: inputs.store-on-tape && startsWith(inputs.remote-environment, 'Gadi')
     environment: ${{ inputs.remote-environment }}
     steps:
@@ -260,6 +265,9 @@ jobs:
             ${{ secrets.SSH_HOST_DATA }}
 
       - name: Send Target to Tape
+        # For each of the absolute paths of copied files and manifests, put
+        # the file (and it's directories relative to inputs.target) on the tape storage
+        # under a datestamp directory.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           now=$(date +%Y_%m_%d_%H_%M)
@@ -267,7 +275,7 @@ jobs:
           mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now
           for file in ${{ needs.copy-to-remote.outputs.files }}; do
             file_relative_to_target=${file#${{ inputs.target }}/}
-            echo "Moving '$file' to ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target"
+            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target'"
             dirs_after_target=$(dirname $file_relative_to_target)
             if [[ "$dirs_after_target" != "." ]]; then
               mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)
@@ -277,7 +285,7 @@ jobs:
 
           for file in ${{ needs.copy-to-remote.outputs.manifests }}; do
             file_relative_to_target=${file#${{ inputs.target }}/}
-            echo "Moving '$file' to ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target"
+            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target'"
             dirs_after_target=$(dirname $file_relative_to_target)
             if [[ "$dirs_after_target" != "." ]]; then
               mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -178,20 +178,27 @@ jobs:
         id: copy
         env:
           REMOTE_RSYNC_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-files-${{ github.run_id }}.log
+          LOCAL_RSYNC_FILE_LIST_PATH: ./files-copied.log
         # In this step, we rsync the files from the source to the target,
         # capturing the list of files copied as output of the step, since
         # it's used in the manifest step.
-        # We also put it in a space-separated format suitable for output.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          rsync --recursive --out-format="%n" \
+          rsync --recursive --out-format="${{ inputs.target }}/%n" \
               ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
               ${{ inputs.source }} ${{ inputs.target }} \
+            | grep --invert-match '/$' \
             | tr '\n' ' ' \
-            | tee ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
+            > ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
           EOT
 
-          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} /dev/stdout)" >> $GITHUB_OUTPUT
+          rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} \
+            ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
+          cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
+          paths=$(cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})
+          echo "paths are $paths"
+          echo "paths=$paths" >> $GITHUB_OUTPUT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
@@ -205,6 +212,8 @@ jobs:
         id: manifest
         env:
           REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}.log
+          LOCAL_MANIFEST_FILE_LIST_PATH: ./manifests-copied.log
+          MANIFEST_FILE_NAME: manifest.yaml
         # Generate manifests for files copied over in the earlier rsync job
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
@@ -212,16 +221,25 @@ jobs:
           module load ${{ vars.YAMF_MODULE_NAME }}
 
           manifest_paths=()
-          while read -r path; do
-            cd $(dirname $path) || exit
-            manifest_dir=$(basename $path)
-            yamf add -n manifest.yaml --force $manifest_dir
-            manifest_paths+=("$manifest_dir/manifest.yaml")
-          done <<< "${{ steps.copy.outputs.paths }}"
+          for path in ${{ steps.copy.outputs.paths }}; do
+            echo "Path is $path"
+            manifest_dir=$(dirname $path)
+            cd $manifest_dir || exit
+            manifest_file=$(basename $path)
+            echo "Generating a manifest in $manifest_dir for $manifest_file"
+            yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_file
+            manifest_paths+=("$manifest_dir/${{ env.MANIFEST_FILE_NAME }}")
+          done
           echo "${manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
           EOT
 
-          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout)" >> $GITHUB_OUTPUT
+          rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} \
+            ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
+          cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
+          paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})
+          echo "paths are $paths"
+          echo "paths=$paths" >> $GITHUB_OUTPUT
 
   copy-to-tape:
     name: Copy To Tape
@@ -229,7 +247,7 @@ jobs:
     needs:
       - copy-to-remote
     # TODO: Generalize the copy-to-tape job for future remote-environments
-    if: inputs.store-on-tape && inputs.remote-environment == 'Gadi'
+    if: inputs.store-on-tape && startsWith(inputs.remote-environment, 'Gadi')
     environment: ${{ inputs.remote-environment }}
     steps:
       - name: Setup SSH
@@ -245,7 +263,28 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           now=$(date +%Y_%m_%d_%H_%M)
+
           mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now
-          mdss -P ${{ vars.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.files }} ${{ vars.TAPE_ROOT_DIR }}/$now
-          mdss -P ${{ vars.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.manifests }} ${{ vars.TAPE_ROOT_DIR }}/$now
+          for file in ${{ needs.copy-to-remote.outputs.files }}; do
+            file_relative_to_target=${file#${{ inputs.target }}/}
+            echo "Moving '$file' to ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target"
+            dirs_after_target=$(dirname $file_relative_to_target)
+            if [[ "$dirs_after_target" != "." ]]; then
+              mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)
+            fi
+            mdss -P ${{ vars.PROJECT_CODE }} put -r $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target
+          done
+
+          for file in ${{ needs.copy-to-remote.outputs.manifests }}; do
+            file_relative_to_target=${file#${{ inputs.target }}/}
+            echo "Moving '$file' to ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target"
+            dirs_after_target=$(dirname $file_relative_to_target)
+            if [[ "$dirs_after_target" != "." ]]; then
+              mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)
+            fi
+            mdss -P ${{ vars.PROJECT_CODE }} put -r $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target
+          done
+
+          echo "Output:"
+          mdss -P ${{ vars.PROJECT_CODE }} ls -R ${{ vars.TAPE_ROOT_DIR }}/$now
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -123,7 +123,12 @@ jobs:
           echo "---- Groups ----"
           groups
 
-          setfacl --test --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ env.TEST_DIR }}
+          if setfacl --test --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ env.TEST_DIR }}; then
+            echo "::notice::ACL Verification Successful. This does not test that the users/groups exist on the remote environment"
+          else
+            echo "::error::ACL Verification Failed. Check the preceding lines."
+            exit 1
+          fi
 
   copy-to-remote:
     name: Copy To ${{ inputs.remote-environment }}

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -58,6 +58,27 @@ jobs:
           echo "::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
           echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
 
+      - name: Verify inputs
+        run: |
+          errors=false
+
+          if [ -z "${{ inputs.source }}"]; then
+            echo "::error::No 'source' input given, can't copy anything."
+            errors=true
+          fi
+          if [ -z "${{ inputs.target }}"]; then
+            echo "::error::No 'target' input given, can't copy to anywhere."
+            errors=true
+          fi
+          if [ -z "${{ inputs.target-acl-spec }}" ]; then
+            echo "::notice::No 'ACL' input given, not setting the ACLs explicitly."
+          fi
+
+          if [[ "$errors" == "true" ]]; then
+            echo "::error::Errors above, exiting..."
+            exit 1
+          fi
+
       - name: Format ACL
         id: fmt
         # Remove spaces from ACL string as we have later logic that relies on
@@ -160,17 +181,17 @@ jobs:
         # In this step, we rsync the files from the source to the target,
         # capturing the list of files copied as output of the step, since
         # it's used in the manifest step.
+        # We also put it in a space-separated format suitable for output.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          files=$(rsync --recursive --out-format="%n" \
+          rsync --recursive --out-format="%n" \
               ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
               ${{ inputs.source }} ${{ inputs.target }} \
-            | tr '\n' ' ' \  # convert to space-separated for output
-            > ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
-          )
+            | tr '\n' ' ' \
+            | tee ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
           EOT
 
-          echo "paths=$(scp -q ${{ secrets.USER }}:${{ secrets.HOST }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
+          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} /dev/stdout)" >> $GITHUB_OUTPUT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
@@ -191,8 +212,8 @@ jobs:
           module load ${{ vars.YAMF_MODULE_NAME }}
 
           manifest_paths=()
-          while read -r path:
-            cd $(dirname $path)
+          while read -r path; do
+            cd $(dirname $path) || exit
             manifest_dir=$(basename $path)
             yamf add -n manifest.yaml --force $manifest_dir
             manifest_paths+=("$manifest_dir/manifest.yaml")
@@ -200,7 +221,7 @@ jobs:
           echo "${manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
           EOT
 
-          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
+          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout)" >> $GITHUB_OUTPUT
 
   copy-to-tape:
     name: Copy To Tape

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -58,13 +58,6 @@ jobs:
           echo "::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
           echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
 
-      - name: Verify Remote Target
-        run: |
-          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "false" ]]; then
-            echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
-            exit 1
-          fi
-
       - name: Format ACL
         id: fmt
         # Remove spaces from ACL string as we have later logic that relies on
@@ -153,6 +146,13 @@ jobs:
             ${{ secrets.SSH_HOST }}
             ${{ secrets.SSH_HOST_DATA }}
 
+      - name: Verify Remote Target
+        run: |
+          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "false" ]]; then
+            echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
+            exit 1
+          fi
+
       - name: Rsync Source to Target
         id: copy
         env:
@@ -161,7 +161,7 @@ jobs:
         # capturing the list of files copied as output of the step, since
         # it's used in the manifest step.
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           files=$(rsync --recursive --out-format="%n" \
               ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
               ${{ inputs.source }} ${{ inputs.target }} \
@@ -175,7 +175,7 @@ jobs:
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ inputs.target }}
           getfacl -t ${{ inputs.target }}
           EOT
@@ -186,10 +186,9 @@ jobs:
           REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}.log
         # Generate manifests for files copied over in the earlier rsync job
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          # FIXME: Make these module use/load an environment variable
-          module use /g/data/vk83/prerelease/modules
-          module load payu
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          module use ${{ vars.YAMF_MODULE_PATH }}
+          module load ${{ vars.YAMF_MODULE_NAME }}
 
           manifest_paths=()
           while read -r path:
@@ -201,7 +200,7 @@ jobs:
           echo "${manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
           EOT
 
-          echo "paths=$(scp -q ${{ secrets.USER }}:${{ secrets.HOST }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
+          echo "paths=$(scp -q ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }} /dev/stdout) >> $GITHUB_OUTPUT
 
   copy-to-tape:
     name: Copy To Tape
@@ -211,9 +210,6 @@ jobs:
     # TODO: Generalize the copy-to-tape job for future remote-environments
     if: inputs.store-on-tape && inputs.remote-environment == 'Gadi'
     environment: ${{ inputs.remote-environment }}
-    env:
-      TAPE_ROOT_DIR: model-config-inputs
-      PROJECT_CODE: vk83
     steps:
       - name: Setup SSH
         id: ssh
@@ -226,9 +222,9 @@ jobs:
 
       - name: Send Target to Tape
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           now=$(date +%Y_%m_%d_%H_%M)
-          mdss -P ${{ env.PROJECT_CODE }} mkdir -p ${{ env.TAPE_ROOT_DIR }}/$now
-          mdss -P ${{ env.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.files }} ${{ env.TAPE_ROOT_DIR }}/$now
-          mdss -P ${{ env.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.manifests }} ${{ env.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ vars.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.files }} ${{ vars.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ vars.PROJECT_CODE }} put -r ${{ needs.copy-to-remote.outputs.manifests }} ${{ vars.TAPE_ROOT_DIR }}/$now
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -119,8 +119,8 @@ jobs:
 
           setfacl --test --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ env.TEST_DIR }}
 
-  remote:
-    name: Remote
+  copy-to-remote:
+    name: Copy To ${{ inputs.remote-environment }}
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -150,4 +150,32 @@ jobs:
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ inputs.target }}
           getfacl -t ${{ inputs.target }}
+          EOT
+
+  copy-to-tape:
+    name: Copy To Tape
+    runs-on: ubuntu-latest
+    needs:
+      - copy-to-remote
+    # TODO: Generalize the copy-to-tape job for future remote-environments
+    if: inputs.remote-environment == 'Gadi'
+    environment: ${{ inputs.remote-environment }}
+    env:
+      TAPE_ROOT_DIR: 'FIXME: Where is it?'
+    steps:
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          private-key: ${{ secrets.SSH_KEY }}
+          hosts: |
+            ${{ secrets.SSH_HOST }}
+            ${{ secrets.SSH_HOST_DATA }}
+
+      - name: Send Target to Tape
+        run: |
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          now=$(date +%Y_%m_%d_%H_%M)
+          mdss mkdir ${{ env.TAPE_ROOT_DIR }}/$now
+          mdss put -r -w ${{ inputs.target }} ${{ env.TAPE_ROOT_DIR }}/$now
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -38,6 +38,12 @@ on:
           d:m::rwx,
           d:o::---
         description: ACL spec to be passed to `setfacl -m` for the given target
+      store-on-tape:
+        type: boolean
+        required: true
+        default: true
+        description: Also store target on the remotes cold storage service
+
 jobs:
   setup:
     name: Setup
@@ -158,7 +164,7 @@ jobs:
     needs:
       - copy-to-remote
     # TODO: Generalize the copy-to-tape job for future remote-environments
-    if: inputs.remote-environment == 'Gadi'
+    if: inputs.store-on-tape && inputs.remote-environment == 'Gadi'
     environment: ${{ inputs.remote-environment }}
     env:
       TAPE_ROOT_DIR: 'FIXME: Where is it?'

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -224,7 +224,7 @@ jobs:
           module use ${{ vars.YAMF_MODULE_PATH }}
           module load ${{ vars.YAMF_MODULE_NAME }}
 
-          manifest_paths=()
+          declare -A manifest_paths
           for path in ${{ steps.copy.outputs.paths }}; do
             echo "Path is $path"
             manifest_dir=$(dirname $path)
@@ -233,9 +233,9 @@ jobs:
             echo "Generating a manifest entry in $manifest_dir for $manifest_file"
 
             yamf add -n ${{ env.MANIFEST_FILE_NAME }} --force $manifest_file
-            manifest_paths+=("$manifest_dir/${{ env.MANIFEST_FILE_NAME }}")
+            manifest_paths["$manifest_dir/${{ env.MANIFEST_FILE_NAME }}"]=1
           done
-          echo "${manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
+          echo "${!manifest_paths[@]}" > ${{ env.REMOTE_MANIFEST_FILE_LIST_PATH }}
           EOT
 
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \


### PR DESCRIPTION
See closed https://github.com/ACCESS-NRI/model-config-tests/pull/65 that is recreated here:

## Background

This PR adds a new user-dispatchable workflow for the moving of configuration input files across the same remote host as a service user. This is useful for allowing `/g/data/vk83` to remain as a kind of human-free-zone when it comes to important files.

Furthermore, this PR will add inputs moved into tape storage under a datestamp-based subdirectory. 

## The PR 

In this PR:
- **Add new inputs-remote-copy dispatchable workflow that includes tape storage functionality**

Repository Settings Modified:
- Added `Gadi` GitHub Environment for access to remote `Gadi`

## Testing

Tested in https://github.com/codegat-test-org/test/actions/runs/11118267239

Closes ACCESS-NRI/model-config-inputs#1
