### PR TITLE
Add generate_manifests.bash script for generation of `yamf` manifests at a large scale

### DIFF
--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -1,24 +1,6 @@
 #!/bin/bash
 # Script for the initial generation of manifest.yaml files in inputs directories
 
-traverse_dir() {
-  dir_without_subdir=$(find "$1" -type d ! -iwholename '*.git*' -links 2 ! -empty)
-
-  for dir in $dir_without_subdir; do
-    echo "Working on $dir:"
-    # Find all the files that we want to turn into manifests
-    files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
-    if [ -n "$files" ]; then
-      # If there are some files, add them using yamf
-      cd "$dir" || exit 2
-      # shellcheck disable=SC2086
-      yamf add -n manifest.yaml $files
-      cd - || exit 2
-    fi
-  done
-}
-
-# Start traversal from the directory passed as an argument
 if [[ $# -ne 3 ]]; then
   echo "Error, arguments required are not given."
   exit 1
@@ -31,6 +13,19 @@ start_dir="${3:-.}"
 module use "$yamf_module_path"
 module load "$yamf_module_name"
 
-traverse_dir "$start_dir"
+dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -empty)
+
+for dir in $dir_without_subdir; do
+  echo "Working on $dir:"
+  # Find all the files that we want to turn into manifests
+  files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
+  if [ -n "$files" ]; then
+      # If there are some files, add them using yamf
+      cd "$dir" || exit 2
+      # shellcheck disable=SC2086
+      yamf add -n manifest.yaml $files
+      cd - || exit 2
+  fi
+done
 
 module unload "$yamf_module_name"

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -2,17 +2,20 @@
 # Script for the initial generation of manifest.yaml files in inputs directories
 
 if [[ $# -ne 3 ]]; then
-  echo "Error, arguments required are not given."
+  echo "Error, arguments required are not given. Usage: $(basename "$0") YAMF_MODULE_PATH YAMF_MODULE_NAME START_DIR"
+  echo "Where: YAMF_MODULE_PATH is the path to a module folder, YAMF_MODULE_NAME is the name of a module that contains yamf, and START_DIR is a directory to begin searching for leaf nodes."
   exit 1
 fi
 
 yamf_module_path="${1}"
 yamf_module_name="${2}"
+# Defaults to '.' unless the third argument is given
 start_dir="${3:-.}"
 
 module use "$yamf_module_path"
 module load "$yamf_module_name"
 
+# This command finds all the leaf directories: see https://unix.stackexchange.com/questions/68577/find-directories-that-do-not-contain-subdirectories/203991#203991
 dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -empty)
 
 for dir in $dir_without_subdir; do
@@ -28,4 +31,3 @@ for dir in $dir_without_subdir; do
   fi
 done
 
-module unload "$yamf_module_name"

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -2,20 +2,10 @@
 # Script for the initial generation of manifest.yaml files in inputs directories
 
 traverse_dir() {
-  local dir="$1"
-  local contains_subdir=false
-
-  # Loop through the directory contents
-  for file in "$dir"/*; do
-    if [ -d "$file" ]; then
-      contains_subdir=true
-      traverse_dir "$file"
-    fi
-  done
-
-  # If the directory does not contain any subdirectories...
-  if [ "$contains_subdir" = false ]; then
+  dir_without_subdir=$(find "$1" -type d -links 2 ! -empty)
+  for dir in $dir_without_subdir; do
     echo "Working on $dir:"
+    ...
     # Find all the files that we want to turn into manifests
     files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
     if [ -n "$files" ]; then

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -20,6 +20,7 @@ traverse_dir() {
     files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
     if [ -n "$find" ]; then
       # If there are some files, add them using yamf
+      cd "$dir" || exit 2
       # shellcheck disable=SC2086
       yamf add -n manifest.yaml $files
     fi

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -18,7 +18,7 @@ traverse_dir() {
     echo "Working on $dir:"
     # Find all the files that we want to turn into manifests
     files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
-    if [ -n "$find" ]; then
+    if [ -n "$files" ]; then
       # If there are some files, add them using yamf
       cd "$dir" || exit 2
       # shellcheck disable=SC2086

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -22,13 +22,6 @@ traverse_dir() {
       # If there are some files, add them using yamf
       # shellcheck disable=SC2086
       yamf add -n manifest.yaml $files
-    else
-      # Else we need to create an empty manifest file...
-      cat <<EOT >> manifest.yaml
-format: yamanifest
-version: 1.0
----
-EOT
     fi
   fi
 }

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -13,6 +13,7 @@ traverse_dir() {
       cd "$dir" || exit 2
       # shellcheck disable=SC2086
       yamf add -n manifest.yaml $files
+      cd - || exit 2
     fi
   done
 }

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -33,6 +33,19 @@ EOT
   fi
 }
 
-# Start traversal from the directory passed as an argument, or current directory
-start_dir="${1:-.}"
+# Start traversal from the directory passed as an argument
+if [[ $# -ne 3 ]]; then
+  echo "Error, arguments required are not given."
+  exit 1
+fi
+
+yamf_module_path="${1}"
+yamf_module_name="${2}"
+start_dir="${3:-.}"
+
+module use "$yamf_module_path"
+module load "$yamf_module_name"
+
 traverse_dir "$start_dir"
+
+module unload "$yamf_module_name"

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script for the initial generation of manifest.yaml files in inputs directories
+
+traverse_dir() {
+  local dir="$1"
+  local contains_subdir=false
+
+  # Loop through the directory contents
+  for file in "$dir"/*; do
+    if [ -d "$file" ]; then
+      contains_subdir=true
+      traverse_dir "$file"
+    fi
+  done
+
+  # If the directory does not contain any subdirectories...
+  if [ "$contains_subdir" = false ]; then
+    echo "Working on $dir:"
+    # Find all the files that we want to turn into manifests
+    files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
+    if [ -n "$find" ]; then
+      # If there are some files, add them using yamf
+      # shellcheck disable=SC2086
+      yamf add -n manifest.yaml $files
+    else
+      # Else we need to create an empty manifest file...
+      cat <<EOT >> manifest.yaml
+format: yamanifest
+version: 1.0
+---
+EOT
+    fi
+  fi
+}
+
+# Start traversal from the directory passed as an argument, or current directory
+start_dir="${1:-.}"
+traverse_dir "$start_dir"

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -2,10 +2,10 @@
 # Script for the initial generation of manifest.yaml files in inputs directories
 
 traverse_dir() {
-  dir_without_subdir=$(find "$1" -type d -links 2 ! -empty)
+  dir_without_subdir=$(find "$1" -type d ! -iwholename '*.git*' -links 2 ! -empty)
+
   for dir in $dir_without_subdir; do
     echo "Working on $dir:"
-    ...
     # Find all the files that we want to turn into manifests
     files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
     if [ -n "$files" ]; then
@@ -14,7 +14,7 @@ traverse_dir() {
       # shellcheck disable=SC2086
       yamf add -n manifest.yaml $files
     fi
-  fi
+  done
 }
 
 # Start traversal from the directory passed as an argument


### PR DESCRIPTION
In this PR:
* Version-control the script that will be used to generate `manifest.yaml` files at a large scale (namely, the entire `/g/data/vk83/configurations/inputs` directory!) at the leaf of every part of the tree
