### PR TITLE
Commit manifests on Remote

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -251,14 +251,25 @@ jobs:
             ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
           echo "paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
+      - name: Import Commit-Signing Key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
       - name: Commit Updated Manifests to ${{ github.repository }}
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -A -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           cd "${{ vars.CONFIGS_INPUT_DIR }}" || echo "::error::Can't CD into vars.CONFIGS_INPUT_DIR to commit" && exit 2
           git add .
-          # FIXME: How do I feed in the secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE to the below non-interactively?
           git commit -m "Updated manifests as part of ${{ env.RUN_URL }}"
           git push
           EOT

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -251,23 +251,15 @@ jobs:
             ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
           echo "paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
-      - name: Import Commit-Signing Key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
-        with:
-          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
-          git_config_global: true
-          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
-          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_tag_gpgsign: true
-
       - name: Commit Updated Manifests to ${{ github.repository }}
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -A -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          eval $(gpg-agent --daemon)
+          $(gpgconf --list-dirs libexecdir)/gpg-preset-passphrase \
+            --passphrase '${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}' \
+            --preset '${{ secrets.GH_ACTIONS_BOT_GPG_KEYGRIP }}'
           cd "${{ vars.CONFIGS_INPUT_DIR }}" || echo "::error::Can't CD into vars.CONFIGS_INPUT_DIR to commit" && exit 2
           git add .
           git commit -m "Updated manifests as part of ${{ env.RUN_URL }}"

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -251,6 +251,18 @@ jobs:
             ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }}
           echo "paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
+      - name: Commit Updated Manifests to ${{ github.repository }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          cd "${{ vars.CONFIGS_INPUT_DIR }}" || echo "::error::Can't CD into vars.CONFIGS_INPUT_DIR to commit" && exit 2
+          git add .
+          # FIXME: How do I feed in the secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE to the below non-interactively?
+          git commit -m "Updated manifests as part of ${{ env.RUN_URL }}"
+          git push
+          EOT
+
   copy-to-tape-gadi:
     name: Copy To Tape On ${{ inputs.remote-environment }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Background

In this PR:
* Add a step to the `copy-to-remote` job in which we add, commit and push the manifests just updated in earlier steps on the remote.

## Open Questions

* ~Do we commit directly to `main` as a rule-bypassing service user? Or open a PR for something that will nevertheless always be committed?~ I think that we should commit to main. 
* ~How do we feed in the `secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE` non-interactively on the remote? Usually we have a local action to handle this.~ Solved with @tmcadam! Use `gpg-agent` and `gpg-preset-passphrase`! 

Closes #7
