### PR TITLE
Remove `.git*` dirs and `manifest.yaml` from manifest creation

### DIFF
--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -16,12 +16,12 @@ module use "$yamf_module_path"
 module load "$yamf_module_name"
 
 # This command finds all the leaf directories: see https://unix.stackexchange.com/questions/68577/find-directories-that-do-not-contain-subdirectories/203991#203991
-dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -empty)
+dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -iwholename "*.git*" ! -empty)
 
 for dir in $dir_without_subdir; do
   echo "Working on $dir:"
   # Find all the files that we want to turn into manifests
-  files=$(find "$dir" -maxdepth 1 -type f -printf '%f ')
+  files=$(find "$dir" -maxdepth 1 -type f ! -name "manifest.yaml" -printf '%f ')
   if [ -n "$files" ]; then
       # If there are some files, add them using yamf
       cd "$dir" || exit 2

--- a/.github/scripts/generate_manifests.bash
+++ b/.github/scripts/generate_manifests.bash
@@ -16,7 +16,7 @@ module use "$yamf_module_path"
 module load "$yamf_module_name"
 
 # This command finds all the leaf directories: see https://unix.stackexchange.com/questions/68577/find-directories-that-do-not-contain-subdirectories/203991#203991
-dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -iwholename "*.git*" ! -empty)
+dir_without_subdir=$(find "$start_dir" -type d -links 2 ! -ipath "*.git*" ! -empty)
 
 for dir in $dir_without_subdir; do
   echo "Working on $dir:"


### PR DESCRIPTION
This PR removes `.git*` directories from manfiest file creation, and `manifest.yaml` from being a possible file to generate a `yamf` entry for. 

Closes #9
