### PR TITLE
Add `inputs.note` Field to Help Approvers Make Decisions

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -10,6 +10,10 @@ on:
         options:
           - Gadi
           - Gadi Prerelease
+      note:
+        type: string
+        required: false
+        description: Note describing the reason for the change
       source:
         type: string
         required: true
@@ -56,6 +60,9 @@ jobs:
       - name: Log inputs
         run: |
           echo "::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
+          if [[ "${{ inputs.note }}" != "" ]]; then
+            echo "::notice::Note from ${{ github.actor }}: '${{ inputs.note }}'"
+          fi
           echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
 
       - name: Verify inputs


### PR DESCRIPTION
In this PR:
* Add an `inputs.note` field that is echoed as a notice to approvers when the deployment review is requested. Users can put in a rationale for the copy, if they like!

Closes #11
