### PR TITLE
Fix to `rsync` non-dir doubling filename in `--output-format`

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -17,11 +17,11 @@ on:
       source:
         type: string
         required: true
-        description: Remote absolute path to configuration input source
+        description: Remote absolute path to configuration input source file or directory
       target:
         type: string
         required: true
-        description: Remote absolute path to configuration input destination
+        description: Remote absolute path to configuration input destination directory
       overwrite-target:
         type: boolean
         required: true
@@ -69,12 +69,8 @@ jobs:
         run: |
           errors=false
 
-          if [ -z "${{ inputs.source }}"]; then
-            echo "::error::No 'source' input given, can't copy anything."
-            errors=true
-          fi
-          if [ -z "${{ inputs.target }}"]; then
-            echo "::error::No 'target' input given, can't copy to anywhere."
+          if [[ "$(basename "${{ inputs.source }}")" == "$(basename "${{ inputs.target }}")" ]]; then
+            echo "::error::Attempted to copy a file into a file (destination must be a directory) or copy a directory into one with the same name (common rsync error)"
             errors=true
           fi
           if [ -z "${{ inputs.target-acl-spec }}" ]; then
@@ -194,18 +190,13 @@ jobs:
         # and then one locally on the runner to copy the list of files from the remote.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-
-          # Determine whether the transfer is of directories or a file.
           # Create intermediate directories since we can't use `rsync`s `--mkpath` on some deployment targets
-          # Also set RSYNC_OUT_FORMAT - this is used to get the absolute path of the file(s) transferred via rsync
-          if [ -d "${{ inputs.source }}" ]; then
-            mkdir -p "${{ inputs.target }}"
-            RSYNC_OUT_FORMAT='${{ inputs.target }}/%n'  # the target dir + files
-          else  # we can assume we are transferring a file
-            mkdir -p $(dirname "${{ inputs.target }}")
-            RSYNC_OUT_FORMAT='${{ inputs.target }}'  # the target file
-          fi
+          mkdir -p "${{ inputs.target }}"
 
+          # The output of the rsync command will be a list of transferred absolute paths, for further processing
+          RSYNC_OUT_FORMAT="$(readlink -f "${{ inputs.target }}")/%n"
+
+          # Transfer the source to the target, and pipe a space-separated list of destination file paths
           rsync --recursive --out-format="$RSYNC_OUT_FORMAT" \
               ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
               ${{ inputs.source }} ${{ inputs.target }} \

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -195,14 +195,18 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
 
+          # Determine whether the transfer is of directories or a file.
           # Create intermediate directories since we can't use `rsync`s `--mkpath` on some deployment targets
+          # Also set RSYNC_OUT_FORMAT - this is used to get the absolute path of the file(s) transferred via rsync
           if [ -d "${{ inputs.source }}" ]; then
             mkdir -p "${{ inputs.target }}"
+            RSYNC_OUT_FORMAT='${{ inputs.target }}/%n'  # the target dir + files
           else  # we can assume we are transferring a file
             mkdir -p $(dirname "${{ inputs.target }}")
+            RSYNC_OUT_FORMAT='${{ inputs.target }}'  # the target file
           fi
 
-          rsync --recursive --out-format="${{ inputs.target }}/%n" \
+          rsync --recursive --out-format="$RSYNC_OUT_FORMAT" \
               ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
               ${{ inputs.source }} ${{ inputs.target }} \
             | grep --invert-match '/$' \


### PR DESCRIPTION
In this PR:
* We require that the `inputs.target` always be a directory, NOT a file, and add required checks for this. 
  * This simplifies the `--out-format` to `${{ inputs.target }}/%n`, which gives the absolute target + filenames

This resolves the issue where a file is transferred and the out format ends up having a duplicated filename at the end: eg. `/g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/basins/global.1deg/2020.05.19/basin_mask.nc/%n` -> `/g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/basins/global.1deg/2020.05.19/basin_mask.nc/basin_mask.nc`

Closes #15
