### PR TITLE
Update `cd` exit case

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -262,7 +262,12 @@ jobs:
           $(gpgconf --list-dirs libexecdir)/gpg-preset-passphrase \
             --passphrase '${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}' \
             --preset '${{ secrets.GH_ACTIONS_BOT_GPG_KEYGRIP }}'
-          cd "${{ vars.CONFIGS_INPUT_DIR }}" || echo "::error::Can't CD into vars.CONFIGS_INPUT_DIR to commit" && exit 2
+
+          if ! cd "${{ vars.CONFIGS_INPUT_DIR }}"; then
+            echo "::error::Can't CD into vars.CONFIGS_INPUT_DIR to commit"
+            exit 2
+          fi
+
           git add .
           git commit -m "Updated manifests as part of ${{ env.RUN_URL }}"
           git push


### PR DESCRIPTION
In this PR:
* Rather than think I'm slick with all the `||`/`&&` one-liner exit code stuff (which [didn't work](https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/12111983163/job/33764720424#step:7:16)), make the failure case for the `cd` more explicit. 

Closes #19
