### PR TITLE
remote-copy.yml: Only allow `Gadi` remote-environment to push commits back

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -254,6 +254,8 @@ jobs:
           echo "paths=$(cat ${{ env.LOCAL_MANIFEST_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
       - name: Commit Updated Manifests to ${{ github.repository }}
+        # TODO: For future remote-environments, we would have to alter the structure of model-config-inputs to be demarcated by target at the root level. For now, only allow Gadi to commit.
+        if: inputs.remote-environment == 'Gadi'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |


### PR DESCRIPTION
In this PR:
* As a stop-gap measure, only allow `Gadi` to commit back results of the workflow. `Gadi Prerelease` would change too much, and other future environments (`Setonix`, `Setonix Prerelease`) would need changes to `model-config-inputs` repo structure. 

Closes #22
