### PR TITLE
Fix Intermediate Directory Creation Logic for Tape Storage

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -300,16 +300,16 @@ jobs:
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           now=$(date +%Y_%m_%d_%H_%M)
 
-          mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now
-
           for file in ${{ needs.copy-to-remote.outputs.files }} ${{ needs.copy-to-remote.outputs.manifests }}; do
-            file_relative_to_target=${file#${{ inputs.target }}/}
-            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target'"
-            dirs_after_target=$(dirname $file_relative_to_target)
-            if [[ "$dirs_after_target" != "." ]]; then
-              mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$(dirname $file_relative_to_target)
-            fi
-            mdss -P ${{ vars.PROJECT_CODE }} put -r $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_target
+            file_relative_to_config_dir=${file#${{ vars.CONFIGS_INPUT_DIR }}/}
+            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_config_dir'"
+
+            # Create all intermediate directories before putting the file
+            intermediate_dirs=$(dirname $file_relative_to_config_dir)
+            mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$intermediate_dirs
+
+            # Copy the file itself to tape
+            mdss -P ${{ vars.PROJECT_CODE }} put $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_config_dir
           done
 
           echo "Output:"


### PR DESCRIPTION
Closes #24

## Background

A bug was found where the intermediate directories created on tape were relative to `inputs.target` (which would almost always be `.`). This PR fixes that.

In this PR:

* Instead of the file being copied relative to the target, copy the file relative to the start of the configurations directory. This should give the correct structure of `model-config-inputs/$now/access-om2/blah/file.nc`, for example. 
* Removed early creation of `model-config-inputs/$now` directories - it's done in a later `mkdir` call
* Added comments!

## Testing

Ran the updated code line-by-line with the example file: `/g/data/vk83/configurations/inputs/access-om2/CHANGELOG`, and verified that the path was as expected:
```shell
$ mdss -P vk83 ls model-config-inputs/2025_02_06_09_54/access-om2
CHANGELOG
```
