### PR TITLE
Tape Storage: Demarcate Release/Prerelease Config Inputs

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -302,16 +302,16 @@ jobs:
 
           for file in ${{ needs.copy-to-remote.outputs.files }} ${{ needs.copy-to-remote.outputs.manifests }}; do
             file_relative_to_config_dir=${file#${{ vars.CONFIGS_INPUT_DIR }}/}
-            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_config_dir'"
+            echo "Moving '$file' to '${{ vars.TAPE_ROOT_DIR }}/${{ vars.ENVIRONMENT_TYPE }}/$now/$file_relative_to_config_dir'"
 
             # Create all intermediate directories before putting the file
             intermediate_dirs=$(dirname $file_relative_to_config_dir)
-            mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/$now/$intermediate_dirs
+            mdss -P ${{ vars.PROJECT_CODE }} mkdir -p ${{ vars.TAPE_ROOT_DIR }}/${{ vars.ENVIRONMENT_TYPE }}/$now/$intermediate_dirs
 
             # Copy the file itself to tape
-            mdss -P ${{ vars.PROJECT_CODE }} put $file ${{ vars.TAPE_ROOT_DIR }}/$now/$file_relative_to_config_dir
+            mdss -P ${{ vars.PROJECT_CODE }} put $file ${{ vars.TAPE_ROOT_DIR }}/${{ vars.ENVIRONMENT_TYPE }}/$now/$file_relative_to_config_dir
           done
 
           echo "Output:"
-          mdss -P ${{ vars.PROJECT_CODE }} ls -R ${{ vars.TAPE_ROOT_DIR }}/$now
+          mdss -P ${{ vars.PROJECT_CODE }} ls -R ${{ vars.TAPE_ROOT_DIR }}/${{ vars.ENVIRONMENT_TYPE }}/$now
           EOT


### PR DESCRIPTION
## Background

Prerelease config inputs have been being erroneously copied to tape. However, after some overwriting of prerelease configurations (and subsequent return of these config inputs from the tape storage), we have decided that this bug is actually a feature. 

But we need to demarcate prerelease and release configs copied to tape, as currently our structure is (irrespective of config contents:

```
model-config-inputs/
├── 2023_12_13_10_10
├── 2023_12_13_10_11
└── 2023_12_13_10_12
```

We propose an intermediate structure of:

```
model-config-inputs/
├── 2023_12_13_10_10
├── 2023_12_13_10_11
├── 2023_12_13_10_12
├── release/
│   ├── 2025_09_93_12_00
│   └── 2025_09_93_12_01
└── prerelease/
    ├── 2025_09_93_12_02
    └── 2025_09_93_12_03
```

So release and prerelease configs are separated. In future, we will sort the existing top-level dated directories in the release/prerelease directories. See https://github.com/ACCESS-NRI/model-config-inputs/issues/28

> [!NOTE]
> Since users don't have to go through the workflow to add/delete/modify prerelease config inputs, the backups under `prerelease` will be partial.


## The PR

* Add an intermediate directory to the tape, of the form: `model-config-inputs/[release|prerelease]/$now`
* Add `vars.ENVIRONMENT_TYPE` to the `Gadi`, `Gadi Prerelease` GitHub Environments, set to `release`, `prerelease` respectively. 
