### PR TITLE
Copy READMEs to repository

### DIFF
--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -271,7 +271,7 @@ jobs:
           fi
 
           git add .
-          git commit -m "Updated manifests as part of ${{ env.RUN_URL }}"
+          git commit -m "Updated manifests and READMEs as part of ${{ env.RUN_URL }}"
           git push
           EOT
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@
 # And allow the leaf manifest.yamls
 !manifest.yaml
 !.manifest.yaml
+# As well as the READMEs...
+!README
+!README.md
+!README.txt
 # and the .gitignore
 !.gitignore


### PR DESCRIPTION
Closes #35

## Background

We should commit READMEs to the repository, so we have a bit more of an idea of what each folder is about. 

> [!NOTE]
> Post-merge, a commit will be added from Gadi that will contain all the READMEs found

## The PR

- **Update .gitignore to not ignore README/README[.md|.txt]**
- **Update commit message**

## Open Questions

* The `README`s will be added to the `.manifest.yaml`  files at the leaf nodes - is that ok @aidanheerdegen ?

## Testing

I sneakily edited the `.gitignore` on Gadi to see what would be committed (before reverting it), and it is:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	JRA-55/RYF/README
	access-esm1p5/modern/amip/restart/2023.03.13/atmosphere/README
	access-esm1p5/modern/historical/restart/atmosphere/README
	access-esm1p5/modern/historical/restart/coupler/README
	access-esm1p5/modern/historical/restart/ice/README
	access-esm1p5/modern/historical/restart/ocean/README
	access-esm1p6/modern/1pctCO2/restart/2026.04.14/README
	access-esm1p6/modern/flat10/restart/2026.04.28/README
	access-esm1p6/modern/historical/atmosphere/land/biogeochemistry/global.N96/2026.03.27/README
	access-esm1p6/modern/historical/atmosphere/land/biogeochemistry/global.N96/2026.05.08/README
	access-esm1p6/modern/historical/atmosphere/land/vegetation/global.N96/2024.11.22/README.md
	access-esm1p6/modern/historical/atmosphere/land/vegetation/global.N96/2026.05.08/README
	access-esm1p6/modern/pre-industrial-emissions/restart/2026.02.23/README
	access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/README
	access-esm1p6/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2026.03.27/README
	access-esm1p6/modern/pre-industrial/restart/2026.04.07/README
	access-esm1p6/modern/pre-industrial/restart/2026.04.15B/README
	access-esm1p6/modern/pre-industrial/restart/README
	access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/README
	access-om2/README.txt
	access-om2/ice/grids/global.025deg/2023.05.15/README
	access-om2/ice/initial_conditions_biogeochemistry/global.01deg/2022.02.24/README
	access-om2/ice/initial_conditions_biogeochemistry/global.025deg/2022.02.24/README
	access-om2/ice/initial_conditions_biogeochemistry/global.1deg/2022.02.24/README
	access-om2/ocean/biogeochemistry/global.01deg/2022.02.24/README
	access-om2/ocean/biogeochemistry/global.025deg/2022.02.24/README
	access-om2/ocean/biogeochemistry/global.1deg/2022.02.24/README
	access-om2/ocean/grids/bathymetry/global.025deg/2023.05.15/README
	access-om2/ocean/processor_masks/global.025deg/1456.48x40/2023.05.15/README
	access-om2/remapping_weights/JRA55/global.025deg/2023.05.15/README
	access-om3/README.txt
	access-om3/bling/forcing/global.100km/2023.08.16/README.txt
	access-om3/bling/forcing/global.1deg/2023.08.16/README.txt
	access-om3/bling/initial_conditions/global.100km/2023.08.16/README.txt
	access-om3/bling/initial_conditions/global.1deg/2023.08.16/README.txt
```
