### PR TITLE
PR Workflow for Model Config Inputs

### DIFF
--- a/.github/manifests/input.schema.json
+++ b/.github/manifests/input.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Model Config Inputs Manifest",
+  "description": "Schema for .github/manifests/input.yml used by the PR workflow.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "target",
+    "type",
+    "cold-storage",
+    "overwrite",
+    "inputs"
+  ],
+  "properties": {
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reason for moving the inputs."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Remote target HPC name."
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "Release",
+        "Prerelease"
+      ],
+      "description": "Target configuration type on the remote."
+    },
+    "cold-storage": {
+      "type": "boolean",
+      "description": "Whether to store on cold storage (for example tape)."
+    },
+    "overwrite": {
+      "type": "boolean",
+      "description": "Whether to overwrite existing target paths."
+    },
+    "inputs": {
+      "type": "object",
+      "description": "Map of absolute source path to target path relative to the remote inputs root.",
+      "minProperties": 1,
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^/[^,\\s]+$",
+        "description": "Absolute source path accessible to the service user."
+      },
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[^/,\\s][^,\\s]+$",
+        "description": "Target path relative to the remote configurations input directory."
+      }
+    }
+  }
+}

--- a/.github/manifests/input.yml
+++ b/.github/manifests/input.yml
@@ -1,0 +1,11 @@
+description: |
+  These inputs are being moved because I feel like it!
+target: Gadi
+type: Prerelease
+cold-storage: false
+overwrite: false
+inputs:
+  # Note that the source is an absolute path accessible to the service user
+  # Note that the target is a relative path to the given targets inputs directory,
+  # eg. Gadi Prerelease is /g/data/vk83/prerelease/configurations/inputs
+  /scratch/tm70/tg0447/test: .test/2026.06.00

--- a/.github/manifests/input.yml
+++ b/.github/manifests/input.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./input.schema.json
 description: |
   These inputs are being moved because I feel like it!
 target: Gadi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Read input.yaml fields
         id: fields
         run: |
-          echo "description=$(yq '.description' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          # description could be a multiline field, so we need to heredoc it when appending it to GITHUB_OUTPUT
+          {
+            echo 'description<<EOF'
+            yq -r '.description' ${{ env.INPUT_YAML_PATH }}
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
           echo "target=$(yq '.target' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
           echo "type=$(yq '.type' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
           echo "cold_storage=$(yq '."cold-storage"' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INPUT_YAML_PATH: .github/manifests/input.yml
-      REQUIRED_FIELDS: description target type cold-storage overwrite inputs
+      INPUT_YAML_SCHEMA_PATH: .github/manifests/input.schema.json
+      INPUT_YAML_SCHEMA_VERSION: draft-2019-09
     outputs:
       description: ${{ steps.fields.outputs.description }}
       target: ${{ steps.fields.outputs.target }}
@@ -22,6 +23,17 @@ jobs:
       inputs: ${{ steps.fields.outputs.inputs }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Validate input.yaml schema
+        uses: GrantBirki/json-yaml-validate@3ff75979f3b21171f2e8a44705f0ff4bed30bbc0 # v5.0.0
+        with:
+          mode: fail
+          files: ${{ env.INPUT_YAML_PATH }}
+          json_schema: ${{ env.INPUT_YAML_SCHEMA_PATH }}
+          json_schema_version: ${{ env.INPUT_YAML_SCHEMA_VERSION }}
+          yaml_as_json: true
+          ajv_strict_mode: false
+          use_gitignore: false
 
       - name: Read input.yaml fields
         id: fields
@@ -37,12 +49,6 @@ jobs:
           echo "cold_storage=$(yq '."cold-storage"' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
           echo "overwrite_target=$(yq '.overwrite' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
           echo "inputs=$(yq -r '.inputs | to_entries | map("\(.key) \(.value)") | join(",")' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
-
-      - name: Validate fields
-        if: contains(steps.fields.outputs.*, 'null')
-        run: |
-          echo "::error::Required fields are missing, check: ${{ env.REQUIRED_FIELDS }}"
-          exit 2
 
   call-remote-copy:
     name: Copy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,80 @@
+name: PR
+on:
+  pull_request: &trigger_config
+    branches:
+      - main
+    paths:
+      - .github/manifests/input.yml
+  push: *trigger_config
+jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    env:
+      INPUT_YAML_PATH: .github/manifests/input.yml
+      REQUIRED_FIELDS: description target type cold-storage overwrite inputs
+    outputs:
+      description: ${{ steps.fields.outputs.description }}
+      target: ${{ steps.fields.outputs.target }}
+      type: ${{ steps.fields.outputs.type }}
+      cold-storage: ${{ steps.fields.outputs.cold_storage }}
+      overwrite-target: ${{ steps.fields.outputs.overwrite_target }}
+      inputs: ${{ steps.fields.outputs.inputs }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read input.yaml fields
+        id: fields
+        run: |
+          echo "description=$(yq '.description' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          echo "target=$(yq '.target' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          echo "type=$(yq '.type' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          echo "cold_storage=$(yq '."cold-storage"' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          echo "overwrite_target=$(yq '.overwrite' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+          echo "inputs=$(yq -r '.inputs | to_entries | map("\(.key) \(.value)") | join(",")' ${{ env.INPUT_YAML_PATH }})" >> $GITHUB_OUTPUT
+
+      - name: Validate fields
+        if: contains(steps.fields.outputs.*, 'null')
+        run: |
+          echo "::error::Required fields are missing, check: ${{ env.REQUIRED_FIELDS }}"
+          exit 2
+
+  call-remote-copy:
+    needs:
+      - validate-inputs
+    uses: ./.github/workflows/remote-copy.yml
+    with:
+      remote: ${{ needs.validate-inputs.outputs.target }}
+      type: ${{ needs.validate-inputs.outputs.type }}
+      note: ${{ needs.validate-inputs.outputs.description }}
+      input: ${{ needs.validate-inputs.outputs.inputs }}
+      overwrite-target: ${{ fromJson(needs.validate-inputs.outputs.overwrite-target) }}
+      store-on-tape: ${{ fromJson(needs.validate-inputs.outputs.cold-storage) }}
+      dry-run: ${{ github.event_name == 'pull_request' }}
+    secrets: inherit
+
+  comment-on-pr:
+    name: Comment
+    needs:
+      - validate-inputs
+      - call-remote-copy
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # for commenting on the PR with dry-run results
+    steps:
+      - name: Output Dry Run To PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          comment_body=$(cat <<'EOF'
+          DRY RUN: Files that would be copied to ${{ needs.validate-inputs.outputs.target }} ${{ needs.validate-inputs.outputs.type }}:
+
+          ```
+          ${{ needs.call-remote-copy.outputs.dry-run-copies }}
+          ```
+          EOF
+          )
+
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "$comment_body"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ on:
   push: *trigger_config
 jobs:
   validate-inputs:
+    name: Validate
     runs-on: ubuntu-latest
     env:
       INPUT_YAML_PATH: .github/manifests/input.yml
@@ -39,6 +40,7 @@ jobs:
           exit 2
 
   call-remote-copy:
+    name: Copy
     needs:
       - validate-inputs
     uses: ./.github/workflows/remote-copy.yml

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -162,7 +162,14 @@ jobs:
               errors=true
             fi
 
+            unset IFS
+
             for source_path in $sources; do
+               if [[ "$source_path" != /* ]]; then
+                 echo "::error::Source '$source_path' must be an absolute path."
+                 errors=true
+               fi
+
               if [[ "$(basename "$source_path")" == "$(basename "$target_rel")" ]]; then
                 echo "::error::Entry '$entry' would copy a file into a file or a directory into one with the same name (common rsync error)."
                 errors=true

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -246,7 +246,7 @@ jobs:
           fi
 
   copy-to-remote-dry-run:
-    name: DRY RUN - Copy To ${{ inputs.remote }} ${{ inputs.type }}
+    name: Copy To ${{ inputs.remote }} ${{ inputs.type }} - Dry Run
     if: inputs.dry-run
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -148,6 +148,7 @@ jobs:
               continue
             fi
 
+            # This splits a space-separated 'SOURCE TARGET' into an absolute source, and target relative to the configuration inputs directory.
             sources="${entry% *}"
             target_rel="${entry##* }"
 

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -319,6 +319,9 @@ jobs:
             echo "$rsync_output"
 
             echo "$rsync_output" >> ${{ env.REMOTE_RSYNC_OUTPUTS_FILE }}
+
+            # Removing the empty target directory post-dry-run-rsync
+            rmdir --ignore-fail-on-non-empty --parents "$target"
           done
           EOT
 

--- a/.github/workflows/remote-copy.yml
+++ b/.github/workflows/remote-copy.yml
@@ -1,34 +1,40 @@
 name: Config Inputs Remote Copy
-run-name: "${{ inputs.remote-environment }} Config Input Copy to ${{ inputs.target }}"
+run-name: "${{ inputs.remote }} ${{ inputs.type }} Config Input Copy"
 on:
   workflow_dispatch:
     inputs:
-      remote-environment:
+      remote:
         type: choice
         required: true
-        description: The Github Environment for the given remote
+        description: The HPC that will have it's configurations moved
         options:
-          - Gadi Release
-          - Gadi Prerelease
+          - Gadi
+      type:
+        type: choice
+        required: true
+        description: The type of configuration inputs
+        options:
+          - Release
+          - Prerelease
       note:
         type: string
         required: false
         description: Note describing the reason for the change
-      source:
+      input:
         type: string
         required: true
-        description: Remote absolute path to configuration input source file or directory
-      target:
-        type: string
-        required: true
-        description: Remote absolute path to configuration input destination directory
+        description: |
+          Comma-separated list of 'SOURCE... TARGET' pairs.
+          SOURCE is an absolute path to a file/directory accessible to the service user.
+          TARGET is a directory relative to the configurations input directory on the HPC for a type.
+          Eg. /path/to/copy/access-esm1p5/something access-esm1p5/something/2026.05
       overwrite-target:
         type: boolean
         required: true
         description: Overwrite the remote target if it already exists
       target-acl-spec:
         type: string
-        required: true
+        required: false
         # Default to no write for everyone except tm70_ci
         # TODO: This default will probably not work for other `remote-environment`s
         default: >-
@@ -48,7 +54,70 @@ on:
         required: true
         default: true
         description: Also store target on the remotes cold storage service
-
+      dry-run:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Run the associated commands without actually copying the files
+  workflow_call:
+    inputs:
+      remote:
+        type: string
+        required: true
+        description: The HPC that will have it's configurations moved
+      type:
+        type: string
+        required: true
+        description: The type of configuration inputs
+      note:
+        type: string
+        required: false
+        description: Note describing the reason for the change
+      input:
+        type: string
+        required: true
+        description: |
+          Comma-separated list of 'SOURCE... TARGET' pairs.
+          SOURCE is an absolute path to a file/directory accessible to the service user.
+          TARGET is a directory relative to the configurations input directory on the HPC for a type.
+          Eg. /path/to/copy/access-esm1p5/something access-esm1p5/something/2026.05
+      overwrite-target:
+        type: boolean
+        required: true
+        description: Overwrite the remote target if it already exists
+      target-acl-spec:
+        type: string
+        required: false
+        # Default to no write for everyone except tm70_ci
+        # TODO: This default will probably not work for other `remote-environment`s
+        default: >-
+          u::rwx,
+          u:tm70_ci:rwx,
+          g::r-x,
+          m::rwx,
+          o::---,
+          d:u::rwx,
+          d:u:tm70_ci:rwx,
+          d:g::r-x,
+          d:m::rwx,
+          d:o::---
+        description: ACL spec to be passed to `setfacl -m` for the given target
+      store-on-tape:
+        type: boolean
+        required: true
+        default: true
+        description: Also store target on the remotes cold storage service
+      dry-run:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Run the associated commands without actually copying the files
+    outputs:
+      dry-run-copies:
+        description: Newline-separated list of files copied in 'SOURCE -> TARGET' format
+        value: ${{ jobs.copy-to-remote-dry-run.outputs.copies }}
 jobs:
   setup:
     name: Setup
@@ -59,20 +128,48 @@ jobs:
     steps:
       - name: Log inputs
         run: |
-          echo "::notice::Copy on ${{ inputs.remote-environment }} from '${{ inputs.source }}' to '${{ inputs.target }}' with ACLs '${{ inputs.target-acl-spec }}'"
+          echo "::notice::Copy on ${{ inputs.remote }} ${{ inputs.type }}: '${{ inputs.input }}' with ACLs '${{ inputs.target-acl-spec }}'"
           if [[ "${{ inputs.note }}" != "" ]]; then
             echo "::notice::Note from ${{ github.actor }}: '${{ inputs.note }}'"
           fi
-          echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite ${{ inputs.target }}"
+          echo "::${{ inputs.overwrite-target && 'warning' || 'notice' }}::This operation ${{ inputs.overwrite-target && 'WILL' || 'will not' }} overwrite the target"
 
       - name: Verify inputs
         run: |
           errors=false
+          pairs='${{ inputs.input }}'
+          IFS=,
 
-          if [[ "$(basename "${{ inputs.source }}")" == "$(basename "${{ inputs.target }}")" ]]; then
-            echo "::error::Attempted to copy a file into a file (destination must be a directory) or copy a directory into one with the same name (common rsync error)"
-            errors=true
-          fi
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            if [[ -z "$entry" ]]; then
+              echo "::error::Empty source/target entry found in 'input'."
+              errors=true
+              continue
+            fi
+
+            sources="${entry% *}"
+            target_rel="${entry##* }"
+
+            if [[ "$sources" == "$entry" || -z "$sources" || -z "$target_rel" ]]; then
+              echo "::error::Invalid source/target entry '$entry'. Expected 'SOURCE TARGET'."
+              errors=true
+              continue
+            fi
+
+            if [[ "$target_rel" = /* ]]; then
+              echo "::error::Target '$target_rel' must be relative to the remote configurations input directory."
+              errors=true
+            fi
+
+            for source_path in $sources; do
+              if [[ "$(basename "$source_path")" == "$(basename "$target_rel")" ]]; then
+                echo "::error::Entry '$entry' would copy a file into a file or a directory into one with the same name (common rsync error)."
+                errors=true
+              fi
+            done
+          done
+
           if [ -z "${{ inputs.target-acl-spec }}" ]; then
             echo "::notice::No 'ACL' input given, not setting the ACLs explicitly."
           fi
@@ -148,13 +245,95 @@ jobs:
             exit 1
           fi
 
-  copy-to-remote:
-    name: Copy To ${{ inputs.remote-environment }}
+  copy-to-remote-dry-run:
+    name: DRY RUN - Copy To ${{ inputs.remote }} ${{ inputs.type }}
+    if: inputs.dry-run
     runs-on: ubuntu-latest
     needs:
       - setup
       - test-acl
-    environment: ${{ inputs.remote-environment }}
+    environment: ${{ inputs.remote }} ${{ inputs.type }}
+    outputs:
+      copies: ${{ steps.dry-run.outputs.copies }}
+    steps:
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          private-key: ${{ secrets.SSH_KEY }}
+          hosts: |
+            ${{ secrets.SSH_HOST }}
+            ${{ secrets.SSH_HOST_DATA }}
+
+      - name: Verify Remote Target
+        run: |
+          pairs='${{ inputs.input }}'
+          IFS=,
+
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            sources="${entry% *}"
+            target_rel="${entry##* }"
+            target="${{ vars.CONFIGS_INPUT_DIR }}/$target_rel"
+
+            if [[ -z "$sources" || -z "$target_rel" || "$sources" == "$entry" ]]; then
+              echo "::error::Invalid source/target entry '$entry'."
+              exit 1
+            fi
+          done
+
+      - name: Rsync Source to Target - Dry Run
+        id: dry-run
+        env:
+          REMOTE_RSYNC_OUTPUTS_FILE: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-dry-run-${{ github.run_id }}-${{ github.run_attempt }}.log
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          pairs='${{ inputs.input }}'
+          IFS=,
+
+          echo "::notice::Dry run output below:"
+
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            sources="${entry% *}"
+            target_rel="${entry##* }"
+            target="${{ vars.CONFIGS_INPUT_DIR }}/$target_rel"
+
+            # Even in dry-run mode, we need to create intermediate directories so rsync's receiver can chdir into the target!
+            mkdir -p "$target"
+
+            rsync_output=$(rsync --dry-run --recursive \
+              --out-format="/%f -> $(realpath "$target")/%n" \
+              $sources $target
+            )
+
+            echo "rsync_output for entry '$entry':"
+            echo "$rsync_output"
+
+            echo "$rsync_output" >> ${{ env.REMOTE_RSYNC_OUTPUTS_FILE }}
+          done
+          EOT
+
+          {
+            echo 'copies<<EOF'
+            ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }} -i ${{ steps.ssh.outputs.private-key-path }} \
+              cat ${{ env.REMOTE_RSYNC_OUTPUTS_FILE }}
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+  copy-to-remote:
+    name: Copy To ${{ inputs.remote }} ${{ inputs.type }}
+    if: ${{ ! inputs.dry-run }}
+    runs-on: ubuntu-latest
+    needs:
+      - setup
+      - test-acl
+    environment: ${{ inputs.remote }} ${{ inputs.type }}
+    concurrency:
+      # We don't want to copy multiple at the same time, especially during the commit step
+      group: ${{ inputs.remote }}-${{ inputs.type }}-config-input-copy
+      cancel-in-progress: false
+      queue: max
     outputs:
       # Space-separated list of paths copied to the target
       files: ${{ steps.copy.outputs.paths }}
@@ -172,50 +351,81 @@ jobs:
 
       - name: Verify Remote Target
         run: |
-          if [[ "${{ startsWith(inputs.target, vars.CONFIGS_INPUT_DIR) }}" == "false" ]]; then
-            echo "::error::Remote target '${{ inputs.target }}' doesn't look like a configurations input directory."
-            exit 1
-          fi
+          pairs='${{ inputs.input }}'
+          IFS=,
+
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            sources="${entry% *}"
+            target_rel="${entry##* }"
+            target="${{ vars.CONFIGS_INPUT_DIR }}/$target_rel"
+
+            if [[ -z "$sources" || -z "$target_rel" || "$sources" == "$entry" ]]; then
+              echo "::error::Invalid source/target entry '$entry'."
+              exit 1
+            fi
+          done
 
       - name: Rsync Source to Target
         id: copy
         # output:
         #   paths: space-separated list of files copied
         env:
-          REMOTE_RSYNC_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-files-${{ github.run_id }}.log
+          REMOTE_RSYNC_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-files-${{ github.run_id }}-${{ github.run_attempt }}.log
           LOCAL_RSYNC_FILE_LIST_PATH: ./files-copied.log
         # In this step, we rsync the files from the source to the target, capturing the list of files copied.
-        # We also remove the empty directories copied, and make it space-separated.
+        # We keep the remote log as one destination path per line, then make it space-separated for output.
         # There are two rsync steps, one for the rsyncing of source to target,
         # and then one locally on the runner to copy the list of files from the remote.
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          # Create intermediate directories since we can't use `rsync`s `--mkpath` on some deployment targets
-          mkdir -p "${{ inputs.target }}"
+          pairs='${{ inputs.input }}'
+          IFS=,
 
-          # The output of the rsync command will be a list of transferred absolute paths, for further processing
-          RSYNC_OUT_FORMAT="$(readlink -f "${{ inputs.target }}")/%n"
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            sources="${entry% *}"
+            target_rel="${entry##* }"
+            target="${{ vars.CONFIGS_INPUT_DIR }}/$target_rel"
 
-          # Transfer the source to the target, and pipe a space-separated list of destination file paths
-          rsync --recursive --out-format="$RSYNC_OUT_FORMAT" \
-              ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
-              ${{ inputs.source }} ${{ inputs.target }} \
-            | grep --invert-match '/$' \
-            | tr '\n' ' ' \
-            | tee ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
+            # Create intermediate directories since we can't use `rsync`s `--mkpath` on some deployment targets
+            mkdir -p "$target"
+
+            # The output of the rsync command will be a list of transferred absolute paths, for further processing
+            RSYNC_OUT_FORMAT="$(realpath "$target")/%n"
+
+            # Transfer the source to the target, and append destination file paths to the remote log.
+            rsync --recursive --out-format="$RSYNC_OUT_FORMAT" \
+                ${{ ! inputs.overwrite-target && '--ignore-existing' || '--update' }} \
+                $sources $target \
+              | grep --invert-match '/$' \
+              >> ${{ env.REMOTE_RSYNC_FILE_LIST_PATH }}
+          done
           EOT
 
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_DATA }}:${{ env.REMOTE_RSYNC_FILE_LIST_PATH }} \
             ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }}
-          echo "paths=$(cat ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
+          echo "paths=$(tr '\n' ' ' < ${{ env.LOCAL_RSYNC_FILE_LIST_PATH }})" >> $GITHUB_OUTPUT
 
       - name: Set ACLs on Target
         if: inputs.target-acl-spec != ''
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" ${{ inputs.target }}
-          getfacl -t ${{ inputs.target }}
+          declare -A targets
+          pairs='${{ inputs.input }}'
+          IFS=,
+
+          for entry in $pairs; do
+            entry=$(echo "$entry" | xargs)
+            target_rel="${entry##* }"
+            targets["${{ vars.CONFIGS_INPUT_DIR }}/$target_rel"]=1
+          done
+
+          for target in "${!targets[@]}"; do
+            setfacl --recursive --modify "${{ needs.setup.outputs.formatted-acl }}" "$target"
+            getfacl -t "$target"
+          done
           EOT
 
       - name: Update Manifests
@@ -223,7 +433,7 @@ jobs:
         # output:
         #   paths: space-separated list of manifests created
         env:
-          REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}.log
+          REMOTE_MANIFEST_FILE_LIST_PATH: ${{ vars.REMOTE_TMP_DIR }}/remote-copy-manifests-${{ github.run_id }}-${{ github.run_attempt }}.log
           LOCAL_MANIFEST_FILE_LIST_PATH: ./manifests-copied.log
           MANIFEST_FILE_NAME: .manifest.yaml
         # Generate manifests for files copied over in the earlier rsync job.
@@ -255,7 +465,7 @@ jobs:
 
       - name: Commit Updated Manifests to ${{ github.repository }}
         # TODO: For future remote-environments, we would have to alter the structure of model-config-inputs to be demarcated by target at the root level. For now, only allow Gadi to commit.
-        if: inputs.remote-environment == 'Gadi Release'
+        if: inputs.type == 'Release'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -276,12 +486,17 @@ jobs:
           EOT
 
   copy-to-tape-gadi:
-    name: Copy To Tape On ${{ inputs.remote-environment }}
+    name: Copy To Tape On ${{ inputs.remote }} ${{ inputs.type }}
     runs-on: ubuntu-latest
     needs:
       - copy-to-remote
-    if: inputs.store-on-tape && startsWith(inputs.remote-environment, 'Gadi')
-    environment: ${{ inputs.remote-environment }}
+    if: inputs.store-on-tape && inputs.remote == 'Gadi'
+    environment: ${{ inputs.remote }} ${{ inputs.type }}
+    concurrency:
+      # We don't want to copy multiple at the same time
+      group: ${{ inputs.remote }}-${{ inputs.type }}-config-input-tape-copy
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Setup SSH
         id: ssh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 !README_template.md
 # and the .gitignore
 !.gitignore
+# and the .github files
+!.github/**


### PR DESCRIPTION
Closes #32

## Background

Currently we allow model configuration input copies from a `workflow_dispatch` trigger, but this doesn't allow very thorough review. 

In this PR, we add a pull-request-style workflow that can make multiple file movements via a `.github/manifests/input.yaml` file. 

Furthermore, one can run a `dry-run` from the Actions tab at the bottom, to see what would be copied. This is the default for pull request events. 

### The Old Workflow

Since there are some small differences around the inputs for the `workflow_dispatch` (AKA, workflow run from the `Actions` tab in the Web UI), I will keep the original workflow on the `old-workflow` branch.

> [!NOTE]
> The old workflow is still on the `old-workflow` branch

## The PR

- **Update .gitignore to include workflows**
- **remote-copy.yml: Add workflow_call trigger, update inputs, update copy logic**
- **Add pr.yml workflow and input.yaml that is used in pull requests**

## Testing

<details>
<summary>Testing details in this section...</summary>

### PR, dry run, single file

Also tests **PR, dry run, multiple entries**

https://github.com/ACCESS-NRI/model-config-inputs/blob/7a85bedd4e2e59c4250dde5eea07a425776d1d69/.github/manifests/input.yml#L11-L12

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27595781034/job/81585743007#step:4:40

### PR, dry run, directory

https://github.com/ACCESS-NRI/model-config-inputs/blob/24c8d74f6925146f8478bded77331a23c4d481f8/.github/manifests/input.yml#L11

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27593485684/job/81578956772#step:4:40

### PR, dry run, multiple entries

https://github.com/ACCESS-NRI/model-config-inputs/blob/7a85bedd4e2e59c4250dde5eea07a425776d1d69/.github/manifests/input.yml#L11-L12

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27595781034/job/81585743007#step:4:40

### Workflow, dry run, single file

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27595334898/job/81584438084#step:4:40

### Workflow, dry run, directory

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27594910341/job/81583160854#step:4:40

### Workflow, real, single file

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27595431643/job/81584709650#step:5:21 and:

```
/g/data/vk83/prerelease/configurations/inputs/.test/
├── esm1p6
│   └── 2026.06.16
│       └── restart_date.nml
 # ...
```

### Workflow, real, directory

Success, https://github.com/ACCESS-NRI/model-config-inputs/actions/runs/27595015447/job/81583605906#step:4:1 and:

```
/g/data/vk83/prerelease/configurations/inputs/.test/
└── om3
    └── 2025.01.30
        ├── grid.nc
        └── kmt.nc
```

### Set up -> Verify Inputs Tests

I turned it into a script with an input being the `inputs.input` input, testing out some failure cases:

```bash
# same basename error
$ ./test.sh "/g/data/vk83/prerelease/configurations/inputs/something access-esm1p6/something"
::error::Entry '/g/data/vk83/prerelease/configurations/inputs/something access-esm1p6/something' would copy a file into a file or a directory into one with the same name (common rsync error).
::error::Errors above, exiting...

# non-absolute source, non-relative target errors
./test.sh "g/data/vk83/prerelease/configurations/inputs/something /access-esm1p6"
::error::Target '/access-esm1p6' must be relative to the remote configurations input directory.
::error::Source 'g/data/vk83/prerelease/configurations/inputs/something' must be an absolute path.
::error::Errors above, exiting...

# malformed SOURCE TARGET error
$ ./test.sh "g/data/vk83/prerelease/configurations/inputs/something"
::error::Invalid source/target entry 'g/data/vk83/prerelease/configurations/inputs/something'. Expected 'SOURCE TARGET'.
::error::Errors above, exiting...

# Correct, multi-pair input
$ ./test.sh "/g/data/vk83/prerelease/configura
tions/inputs/something access-esm1p6/2026.06.01,/g/data/vk83/prerelease/configurations/inputs/another-thing access-esm1p6/2026.06.00,"
```

</details>
